### PR TITLE
Use pkg-config instead of xml2-config

### DIFF
--- a/Makefile.skel
+++ b/Makefile.skel
@@ -41,8 +41,8 @@ VERSION_MIN = 9
 VERSION_REV = 3
 DATE    = xx/xx/xxxx
 
-COMPILE = $(CC) -std=gnu99 -Wall -g `xml2-config --cflags` `gsl-config --cflags` -c -I $(CWD)/src
-LIBS    = $(LINK_FFTW) `xml2-config --libs` `gsl-config --libs` $(LINK_READLINE) -lz -lpng $(LINK_KPATHSEA) -lm
+COMPILE = $(CC) -std=gnu99 -Wall -g `pkg-config --cflags libxml-2.0` `gsl-config --cflags` -c -I $(CWD)/src
+LIBS    = $(LINK_FFTW) `pkg-config --libs libxml-2.0` `gsl-config --libs` $(LINK_READLINE) -lz -lpng $(LINK_KPATHSEA) -lm
 LINK    = $(CC) -std=gnu99 -Wall -g
 
 OPTIMISATION = -O2

--- a/configure
+++ b/configure
@@ -276,10 +276,7 @@ fi
 # 16. CHECK TO SEE WHETHER THIS SYSTEM HAS LIBXML2 HEADERS
 
 echo $ECHO_N "Checking for libxml2-dev       ............. $ECHO_C"
-whichout=`which xml2-config 2> conf.stderr`
-rm -f conf.*
-if test "`echo $whichout | sed 's/\([a-z]*\).*/\1/'`" = "no" ; then whichout="" ; fi
-if test "$whichout" != "" ; then
+if pkg-config --exists libxml-2.0 ; then
  echo "YES"
 else
  echo "NO"


### PR DESCRIPTION
libxml2 no longer includes xml2-config; use pkg-config to get the relevant compiler flags instead.

See https://bugs.debian.org/949487