### PR TITLE
Set reproducible date stamp in plot output

### DIFF
--- a/src/stringTools/asciidouble.c
+++ b/src/stringTools/asciidouble.c
@@ -283,7 +283,20 @@ char *ppl_nextWord(char *in)
 char *ppl_friendlyTimestring()
  {
   time_t timenow;
-  timenow = time(NULL);
+  int override = 0;
+  char *source_date_epoch;
+  source_date_epoch = getenv("SOURCE_DATE_EPOCH");
+  if (source_date_epoch) {
+    errno = 0;
+    timenow = (time_t) strtol (source_date_epoch, NULL, 10);
+    if (errno == 0) {
+      override = 1;
+    }
+  }
+  if (override == 0) {
+    /* get current time */
+    timenow = time(NULL);
+  }
   return( ctime(&timenow) );
  }
 


### PR DESCRIPTION
As part of the reproducible-builds.org project, work is being done to make the building of packages bit-for-bit reproducible (within limits of having the same toolchain). To succeed, build outputs need to not contain timestamps, which forces us to ask why timestamps were included in the first place. The usual case is to help link build outputs to source that generated them and this is the case with pyxplot in its embedding of the generation time into EPS output. The standardised way to preserve this potentially useful timestamping feature is to use the time from the environment variable SOURCE_DATE_EPOCH if it is set. The build system that wants reproducible builds then sets SOURCE_DATE_EPOCH to an appropriate timestamp (in Debian, this is the timestamp that is listed in the changelog for the package, since that is the relevant time for the compilation).

This patch causes EPS creation to use SOURCE_DATE_EPOCH if it is set, enabling reproducible builds of the pyxplot package (since the pyxplot package includes output EPS files as examples).

Debian/Ubuntu have included this patch for pyxplot for about a year.