### PR TITLE
Add a "test" target to top-level Makefile

### DIFF
--- a/Makefile.skel
+++ b/Makefile.skel
@@ -260,3 +260,5 @@ clean:
 
 afresh: clean all
 
+test:
+	+$(MAKE) -C doc test-examples


### PR DESCRIPTION
Add a 'test' target to the top-level Makefile so that a simple 'make test' works.