### PR TITLE
Add DVI special for headers

### DIFF
--- a/src/epsMaker/dvi_interpreter.c
+++ b/src/epsMaker/dvi_interpreter.c
@@ -643,6 +643,11 @@ int dviSpecialImplement(pplerr_context *ec, dviInterpreterState *interp)
    {
     if ((err=dviSpecialColourCommand(ec, interp, interp->spString+6))!=0) return err;
    }
+  // Test for a header string
+  else if (strncmp(interp->spString, "header=", 7) == 0)
+   {
+    if (DEBUG) { sprintf(ec->tempErrStr, "DVI: dvi special to load header ignored"); ppl_log(ec, NULL); }
+   }
   else
    {
     // Unhandled special command (e.g. includegraphics)


### PR DESCRIPTION
Add explicit handling of new DVI specials that load header files so that warnings are not emitted when they are generated by texlive >= 2019.20200218.

For more information, see https://bugs.debian.org/951365

This patch simply drops the DVI special that is unwanted, an alternative approach is to ask latex not to create them to begin with, as described in

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=951365#25

https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=951365;filename=select-dvipdfmx-dvi-driver;msg=25