### PR TITLE
Avoid generating PDF of piechart in examples

### DIFF
--- a/doc/examples/ex_piechart.ppl
+++ b/doc/examples/ex_piechart.ppl
@@ -37,9 +37,7 @@ END
 # END
 
 # Call common cleanup script
-set term pdf
-set output "examples/eps/%s.pdf"%(title)
-refresh
+load "examples/fig_end.ppl"
 
 
 title = "ex_piechart2" ; load "examples/fig_init.ppl"
@@ -54,7 +52,4 @@ END
 # END
 
 # Call common cleanup script
-set term pdf
-set output "examples/eps/%s.pdf"%(title)
-refresh
-
+load "examples/fig_end.ppl"


### PR DESCRIPTION
These are the only PDFs generated within the examples, with the rest being generated using gs within doc/makeFigureEps.py (and these being generated twice, by accident).