### PR TITLE
Add github actions for CI testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: CI tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install fftw3-dev ghostscript imagemagick libcfitsio-dev libgsl-dev libkpathsea-dev libncurses-dev libpng-dev libreadline-dev libxml2-dev pkg-config python3 texlive-fonts-recommended texlive-latex-base texlive-latex-extra wget zlib1g-dev texlive-fonts-extra texlive-latex-recommended texlive-pstricks
+
+    - name: configure
+      run: ./configure
+
+    - name: build
+      run: make
+
+    - name: test
+      run: make -C doc test-examples


### PR DESCRIPTION
This PR creates a [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions) script to configure, build and test pyxplot. It will run on every set of pushes to the master branch and every PR that asks to merge with master.

The cycle takes about 5min to run (2min to install the build-deps, 2 min to build) and an example of what it produces can be seen at https://github.com/llimeht/pyxplot9/runs/1667136819